### PR TITLE
feature: performance boost 

### DIFF
--- a/Calinga.NET/Calinga.NET.csproj
+++ b/Calinga.NET/Calinga.NET.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <PackageId>Calinga.NET</PackageId>
     <Description>Library to integrate Calinga in .NET projects</Description>
-    <Version>1.9.0</Version>
+    <Version>1.9.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Performance improvement by reducing deserializations from cache.

Tested with 10.000 label translations.
Before: ~ 5 minutes
After: ~ 300 milliseconds